### PR TITLE
Fix Collection and Database proxies

### DIFF
--- a/Source/MongoCollectionProxy.cs
+++ b/Source/MongoCollectionProxy.cs
@@ -31,10 +31,10 @@ namespace Dolittle.ReadModels.MongoDB
         /// Initializes a new instance of <see cref="MongoCollectionProxy{T}"/>
         /// </summary>
         /// <param name="configuration"><see cref="Configuration"/> to use</param>
-        public MongoCollectionProxy(IConfigurationFor<Configuration> configuration)
+        public MongoCollectionProxy(Configuration configuration)
         {
-            _configuration = configuration.Instance;
-            _actualCollection = _configuration.Database.GetCollection<T>(typeof(T).Name);
+            _configuration = configuration;
+            _actualCollection = _configuration.Database.GetCollection<T>(typeof(T).FullName);
         }
 
         /// <inheritdoc/>

--- a/Source/MongoDatabaseProxy.cs
+++ b/Source/MongoDatabaseProxy.cs
@@ -27,9 +27,9 @@ namespace Dolittle.ReadModels.MongoDB
         /// Initializes a new instance of <see cref="MongoDatabaseProxy"/>
         /// </summary>
         /// <param name="configuration"><see cref="Configuration"/> to use</param>
-        public MongoDatabaseProxy(IConfigurationFor<Configuration> configuration)
+        public MongoDatabaseProxy(Configuration configuration)
         {
-            _configuration = configuration.Instance;
+            _configuration = configuration;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The MongoCollectionProxy and MongoDatabaseProxy used the wrong configuration object, so it was impossible to use. This is now fixed.

Also the MongoCollectionProxy used just the name of the type as collection name, now it uses the fully qualified name of the type to avoid collisions. Since these classes have never worked - I consider this a non-breaking change.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1149740497685524)
