### PR TITLE
Prevent possible differing Guid representations

### DIFF
--- a/Source/Configuration.cs
+++ b/Source/Configuration.cs
@@ -31,7 +31,7 @@ namespace Dolittle.ReadModels.MongoDB
                         CheckCertificateRevocation = false
                     };
                 }
-
+                s.GuidRepresentation = GuidRepresentation.Standard;
                 Client = new MongoClient(s);
             }
             else


### PR DESCRIPTION
Had an issue with differing Guid representations when using different instances. Fixed by adding a standard Gui representation.